### PR TITLE
Be able to get notifications as a job finishes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -21,7 +21,7 @@ ids.forEach(function(id){
   });
 });
 
-batch.notify(function(i, user){
+batch.on('complete', function(user, i){
   // result of the ith job
 });
 

--- a/lib/batch.js
+++ b/lib/batch.js
@@ -1,4 +1,7 @@
 
+var EventEmitter = require('events').EventEmitter
+  , util = require('util');
+
 /**
  * Expose `Batch`.
  */
@@ -10,12 +13,16 @@ module.exports = Batch;
  */
 
 function Batch() {
+
+  EventEmitter.call(this); 
+
   this.fns = [];
-  this.notifyCb = null;
   for (var i = 0, len = arguments.length; i < len; ++i) {
     this.push(arguments[i]);
   }
 }
+
+util.inherits(Batch, EventEmitter);
 
 /**
  * Queue a function.
@@ -31,20 +38,6 @@ Batch.prototype.push = function(fn){
 };
 
 /**
- * Notifies as soon as a job in batch 
- * finishes `cb(index, result)`.
- *
- * @param {Function} cb
- * @return {Batch}
- * @api public
- */
-
-Batch.prototype.notify = function(cb){
-    this.notifyCb = cb;
-    return this;
-};
-
-/**
  * Execute all queued functions in parallel,
  * executing `cb(err, results)`.
  *
@@ -54,10 +47,10 @@ Batch.prototype.notify = function(cb){
  */
 
 Batch.prototype.end = function(cb){
-  var pending = this.fns.length
+  var that = this
+    , pending = this.fns.length
     , results = []
-    , done
-    , notifyCb = this.notifyCb;
+    , done;
 
   if (!this.fns.length) return cb(null, results);
 
@@ -67,7 +60,7 @@ Batch.prototype.end = function(cb){
       if (err) return done = true, cb(err);
       
       results[index] = res;
-      notifyCb && notifyCb(index, res);
+      that.emit('complete', res, index);
       --pending || cb(null, results);
     });
   });

--- a/test/batch.js
+++ b/test/batch.js
@@ -61,8 +61,8 @@ describe('Batch', function(){
           fn(null, 'bar');
         });
           
-        batch.notify(function(i, result){
-          if(i == 0){
+        batch.on('complete', function(result, index){
+          if(index == 0){
             result.should.equal('foo');
             done();
           } 


### PR DESCRIPTION
Provides support for setting a notification callback. As soon as a job finishes, already set notification callback is called.

```
var batch = new Batch();

...

batch.end(console.log);
batch.notify(function(i, result){
  // result of the ith job
});
```
