### PR TITLE
Fix component version

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ module.exports = Batch;
  */
 
 function Batch() {
-  EventEmitter.call(this);
+  if (EventEmitter) EventEmitter.call(this);
   this.fns = [];
   this.concurrency(Infinity);
   for (var i = 0, len = arguments.length; i < len; ++i) {
@@ -41,7 +41,7 @@ function Batch() {
 if (EventEmitter) {
   Batch.prototype.__proto__ = EventEmitter.prototype;
 } else {
-  Emitter(Batch);
+  Emitter(Batch.prototype);
 }
 
 /**


### PR DESCRIPTION
Oops. currently 2 errors: calling `EventEmitter` constructor in the component version + `Emitter` mixin applied incorrectly.
