### PR TITLE
Various fixes to the component.json; read extended commit for details.

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,8 +1,8 @@
 {
   "name": "batch",
-  "repo": "component/batch",
+  "repo": "visionmedia/batch",
   "description": "Async task batching",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "keywords": ["batch", "async", "utility", "concurrency", "concurrent"],
   "dependencies": {
     "component/emitter": "*"


### PR DESCRIPTION
- visionmedia/batch is the correct repository
- latest version is 0.4.0

I also suggest changing the GitHub repository description at the top of the repository page to remove the `node` specific wording. 

Currently it says:

> batch stuff for node, nothing too exciting
