### PR TITLE
Component v1 Compatibility Issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 
 try {
   var EventEmitter = require('events').EventEmitter;
+  if (!EventEmitter) throw new Error("could not find EventEmitter");
 } catch (err) {
   var Emitter = require('emitter');
 }


### PR DESCRIPTION
In component v1, if `component/events` is included in the build (or any component named `events` for that matter) then this particular `require` will not throw, but will leave both `EventEmitter` and `Emitter` both `undefined`.

To maintain backwards compatibility, this change will work but more [robust solutions](https://github.com/component/component/wiki/Component-and-npm) could be used in the future.

Basically, if `EventEmitter` is still `undefined` after that initial `require`, then it will throw and move into the `catch` block as expected.
