### PR TITLE
Add MIT license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,11 @@
 {
     "name": "batch",
     "version": "0.5.1",
+    "licenses": [
+        {
+            "type": "MIT"
+        }
+    ],
     "description": "Simple async batch",
     "author": "TJ Holowaychuk <tj@vision-media.ca>",
     "devDependencies": {


### PR DESCRIPTION
Allows license to be read programatically.

Update package.json
