### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,7 @@
 {
     "name": "batch",
     "version": "0.5.2",
-    "licenses": [
-        {
-            "type": "MIT"
-        }
-    ],
+    "license": "MIT",
     "description": "Simple async batch",
     "author": "TJ Holowaychuk <tj@vision-media.ca>",
     "devDependencies": {


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/
