### PR TITLE
fix for browserify

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     },
     "main": "index",
     "browser": {
-        "emitter": "component-emitter"
+        "emitter": "events"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Right now you get the following error:

```
Error: Cannot find module 'component-emitter' from '/Users/matt/Projects/rube/node_modules/batch'
    at /Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:46:17
    at process (/Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:173:43)
    at ondir (/Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:188:17)
    at load (/Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:69:43)
    at onex (/Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:92:31)
    at /Users/matt/Projects/rube/node_modules/browserify/node_modules/resolve/lib/async.js:22:47
    at FSReqWrap.oncomplete (fs.js:95:15)
make: *** [browserify] Error 1
```