### PR TITLE
Adding ppc64le architecture support on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,29 @@ node_js:
   - "12.6"
 sudo: false
 dist: trusty
+arch:
+  - amd64
+  - ppc64le
+
+matrix:
+    exclude:
+         - node_js: "0.6"
+           arch: ppc64le
+         - node_js: "0.8"
+           arch: ppc64le
+         - node_js: "0.10"
+           arch: ppc64le
+         - node_js: "0.12"
+           arch: ppc64le
+         - node_js: "1.8"
+           arch: ppc64le
+         - node_js: "2.5"
+           arch: ppc64le
+         - node_js: "3.3"
+           arch: ppc64le
+         - node_js: "4.9"
+           arch: ppc64le
+ 
 env:
   global:
     # Suppress Node.js 0.6 compile warnings


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) architecture support on travis-ci in the PR and looks like its been successfully added. I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.
https://www.travis-ci.com/github/kishorkunal-raj/batch/builds/209332592

Reason behind running tests on ppc64le: This package is included in the ppc64le versions of RHEL and Ubuntu - this allows the top of tree to be tested continuously as it is for Intel, making it easier to catch any possible regressions on ppc64le before the distros begin their clones and builds. This reduces the work in integrating this package into future versions of RHEL/Ubuntu.

Please have a look.

Regards,
Kishor Kunal Raj