### PR TITLE
Supports bundling with `esbuild`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ try {
   try {
     var Emitter = require('emitter');
   } catch (err) {
-    console.error('Unable to create an emitter:', err);
+    throw err
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -12,7 +12,11 @@ try {
   var EventEmitter = require('events').EventEmitter;
   if (!EventEmitter) throw new Error();
 } catch (err) {
-  var Emitter = require('emitter');
+  try {
+    var Emitter = require('emitter');
+  } catch (err) {
+    console.error('Unable to create an emitter:', err);
+  }
 }
 
 /**


### PR DESCRIPTION
As discussed in #42, bundling with [esbuild](https://esbuild.github.io/) currently fails on this package due to an issue on [line 15 of index.js](https://github.com/visionmedia/batch/blob/47a9b1d1f5cd8e4b32dbb74a52aa968cf9b58480/index.js#L15). It references a package called "emitter" that esbuild cannot resolve, thus esbuild fails.

This PR simply wraps the `var Emitter = require('emitter');` line in a `try/catch` block so that even if esbuild cannot resolve it, it will not fail.

Closes #42